### PR TITLE
feat: member joining flow (/[join]/[code], /confirm, token generation)

### DIFF
--- a/app/api/members/route.ts
+++ b/app/api/members/route.ts
@@ -1,7 +1,101 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServiceClient } from "@/lib/supabase";
+import { generateToken } from "@/lib/tokens";
+import { sendEmail } from "@/lib/brevo";
+import ConfirmEmail from "@/emails/ConfirmEmail";
+
 export async function GET() {
   return Response.json({ ok: true });
 }
 
-export async function POST() {
-  return Response.json({ ok: true });
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { name, email, groupId } = body;
+
+  if (!name || !email || !groupId) {
+    return NextResponse.json(
+      { error: "name, email, and groupId are required" },
+      { status: 400 }
+    );
+  }
+
+  const service = createSupabaseServiceClient();
+
+  const { data: group } = await service
+    .from("groups")
+    .select("name")
+    .eq("id", groupId)
+    .single();
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  // Upsert user by email (update name if already exists)
+  const { data: user, error: userError } = await service
+    .from("users")
+    .upsert({ email, name }, { onConflict: "email" })
+    .select("id")
+    .single();
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Failed to create user" }, { status: 500 });
+  }
+
+  // Check for existing membership
+  const { data: existingMember } = await service
+    .from("group_members")
+    .select("id, is_confirmed")
+    .eq("group_id", groupId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (existingMember?.is_confirmed) {
+    return NextResponse.json(
+      { message: "You're already a confirmed member of this group." },
+      { status: 200 }
+    );
+  }
+
+  const confirmToken = generateToken();
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+  const confirmUrl = `${appUrl}/confirm?token=${confirmToken}`;
+
+  if (existingMember) {
+    await service
+      .from("group_members")
+      .update({ confirm_token: confirmToken, confirm_sent_at: new Date().toISOString() })
+      .eq("id", existingMember.id);
+  } else {
+    const { error: memberError } = await service
+      .from("group_members")
+      .insert({
+        group_id: groupId,
+        user_id: user.id,
+        confirm_token: confirmToken,
+        is_confirmed: false,
+        confirm_sent_at: new Date().toISOString(),
+      });
+
+    if (memberError) {
+      return NextResponse.json({ error: "Failed to create membership" }, { status: 500 });
+    }
+  }
+
+  const html = renderToStaticMarkup(
+    React.createElement(ConfirmEmail, { confirmUrl, groupName: group.name })
+  );
+
+  await sendEmail({
+    to: [{ email, name }],
+    subject: `Confirm your membership in ${group.name}`,
+    html,
+  });
+
+  return NextResponse.json(
+    { message: "Check your email to confirm your membership." },
+    { status: 201 }
+  );
 }

--- a/app/confirm/page.tsx
+++ b/app/confirm/page.tsx
@@ -1,3 +1,67 @@
-export default function ConfirmPage() {
-  return <div>{/* TODO: post-confirmation landing */}</div>;
+import { createSupabaseServiceClient } from "@/lib/supabase";
+import { validateConfirmToken } from "@/lib/tokens";
+
+export default async function ConfirmPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>;
+}) {
+  const { token } = await searchParams;
+
+  if (!token) {
+    return (
+      <main className="max-w-md mx-auto p-8">
+        <h1 className="text-2xl font-semibold mb-2">Invalid link</h1>
+        <p className="text-gray-500">This confirmation link is missing a token.</p>
+      </main>
+    );
+  }
+
+  const result = await validateConfirmToken(token);
+
+  if (!result.valid || !result.memberId) {
+    return (
+      <main className="max-w-md mx-auto p-8">
+        <h1 className="text-2xl font-semibold mb-2">Link already used or invalid</h1>
+        <p className="text-gray-500">
+          This confirmation link has already been used or is invalid. If you need a new link,
+          please rejoin using the original invite.
+        </p>
+      </main>
+    );
+  }
+
+  const service = createSupabaseServiceClient();
+
+  const { data: member } = await service
+    .from("group_members")
+    .select("is_confirmed, groups(name)")
+    .eq("id", result.memberId)
+    .single();
+
+  if (member?.is_confirmed) {
+    const groupName = (member.groups as { name: string } | null)?.name ?? "the group";
+    return (
+      <main className="max-w-md mx-auto p-8">
+        <h1 className="text-2xl font-semibold mb-2">Already confirmed</h1>
+        <p className="text-gray-500">Your membership in {groupName} is already confirmed.</p>
+      </main>
+    );
+  }
+
+  await service
+    .from("group_members")
+    .update({ is_confirmed: true, confirm_token: null })
+    .eq("id", result.memberId);
+
+  const groupName = (member?.groups as { name: string } | null)?.name ?? "the group";
+
+  return (
+    <main className="max-w-md mx-auto p-8">
+      <h1 className="text-2xl font-semibold mb-2">You're confirmed!</h1>
+      <p className="text-gray-500">
+        You've successfully joined {groupName}. You'll receive the next newsletter!
+      </p>
+    </main>
+  );
 }

--- a/app/join/[code]/JoinForm.tsx
+++ b/app/join/[code]/JoinForm.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+
+interface JoinFormProps {
+  groupId: string;
+  groupName: string;
+}
+
+export default function JoinForm({ groupId, groupName }: JoinFormProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    const form = new FormData(e.currentTarget);
+    const body = {
+      name: form.get("name"),
+      email: form.get("email"),
+      groupId,
+    };
+    const res = await fetch("/api/members", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    setLoading(false);
+    if (res.ok) {
+      setSubmitted(true);
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setError(data.error ?? "Something went wrong.");
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="py-4">
+        <h2 className="text-xl font-semibold mb-2">Check your email!</h2>
+        <p className="text-gray-500">We sent a confirmation link to your email address.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <label className="flex flex-col gap-1 text-sm">
+        Name
+        <input name="name" required className="border rounded px-3 py-2" />
+      </label>
+      <label className="flex flex-col gap-1 text-sm">
+        Email
+        <input name="email" type="email" required className="border rounded px-3 py-2" />
+      </label>
+      <button
+        type="submit"
+        disabled={loading}
+        className="bg-black text-white rounded px-3 py-2 text-sm disabled:opacity-50 mt-2"
+      >
+        {loading ? "Joining…" : `Join ${groupName}`}
+      </button>
+    </form>
+  );
+}

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -1,4 +1,32 @@
+import { createSupabaseServiceClient } from "@/lib/supabase";
+import JoinForm from "./JoinForm";
+
 export default async function JoinPage({ params }: { params: Promise<{ code: string }> }) {
   const { code } = await params;
-  return <div>{/* TODO: join page for code {code} */}</div>;
+  const service = createSupabaseServiceClient();
+
+  const { data: invite } = await service
+    .from("group_invites")
+    .select("group_id, groups(id, name)")
+    .eq("code", code)
+    .maybeSingle();
+
+  if (!invite) {
+    return (
+      <main className="max-w-md mx-auto p-8">
+        <h1 className="text-2xl font-semibold mb-2">Invite not found</h1>
+        <p className="text-gray-500">This invite link is invalid or has expired.</p>
+      </main>
+    );
+  }
+
+  const group = invite.groups as { id: string; name: string };
+
+  return (
+    <main className="max-w-md mx-auto p-8">
+      <h1 className="text-2xl font-semibold mb-2">Join {group.name}</h1>
+      <p className="text-gray-500 mb-6">Enter your details to join this group.</p>
+      <JoinForm groupId={group.id} groupName={group.name} />
+    </main>
+  );
 }

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,15 +1,33 @@
-export function generateToken(): string {
-  throw new Error("not implemented");
-}
+import { createSupabaseServiceClient } from "./supabase";
 
-export async function validateResponseToken(
-  _token: string
-): Promise<{ valid: boolean; userId?: string; promptId?: string }> {
-  throw new Error("not implemented");
+export function generateToken(): string {
+  return crypto.randomUUID();
 }
 
 export async function validateConfirmToken(
-  _token: string
+  token: string
 ): Promise<{ valid: boolean; memberId?: string }> {
-  throw new Error("not implemented");
+  const service = createSupabaseServiceClient();
+  const { data } = await service
+    .from("group_members")
+    .select("id")
+    .eq("confirm_token", token)
+    .maybeSingle();
+  if (!data) return { valid: false };
+  return { valid: true, memberId: data.id };
+}
+
+export async function validateResponseToken(
+  token: string
+): Promise<{ valid: boolean; userId?: string; promptId?: string }> {
+  const service = createSupabaseServiceClient();
+  const { data } = await service
+    .from("response_tokens")
+    .select("user_id, prompt_id, expires_at, used_at")
+    .eq("token", token)
+    .maybeSingle();
+  if (!data) return { valid: false };
+  if (data.used_at) return { valid: false };
+  if (new Date(data.expires_at) < new Date()) return { valid: false };
+  return { valid: true, userId: data.user_id, promptId: data.prompt_id };
 }


### PR DESCRIPTION
Implements the full member joining flow from issue #13.

## Changes
- `lib/tokens.ts`: implement generateToken, validateConfirmToken, validateResponseToken
- `app/join/[code]/page.tsx`: async server component with invite lookup and 404 handling
- `app/join/[code]/JoinForm.tsx`: client form component with submit + success state
- `app/api/members/route.ts`: upsert user, create pending member, send ConfirmEmail
- `app/confirm/page.tsx`: validate token, mark confirmed, clear token

Closes #13

Generated with [Claude Code](https://claude.ai/code)